### PR TITLE
Fix errors from target field

### DIFF
--- a/spec/helpers/equal-json.ts
+++ b/spec/helpers/equal-json.ts
@@ -1,6 +1,7 @@
 import CustomMatcher = jasmine.CustomMatcher;
 import CustomMatcherResult = jasmine.CustomMatcherResult;
 import CustomMatcherFactories = jasmine.CustomMatcherFactories;
+import { normalizeJSON } from '../regression/helpers';
 const jsondiffpatch = require('jsondiffpatch');
 
 // thanks to https://github.com/jasmine/jasmine/issues/675#issuecomment-127187623
@@ -8,8 +9,8 @@ export const TO_EQUAL_JSON_MATCHERS: CustomMatcherFactories = {
     toEqualJSON: function(util, customEqualityTesters): CustomMatcher {
         return {
             compare: function(actual: any, expected: any): CustomMatcherResult {
-                actual = JSON.parse(JSON.stringify(actual));
-                expected = JSON.parse(JSON.stringify(expected));
+                actual = normalizeJSON(actual);
+                expected = normalizeJSON(expected);
                 const pass = util.equals(actual, expected, customEqualityTesters);
                 return {
                     pass,

--- a/spec/regression/data/errors-in-join.config.ts
+++ b/spec/regression/data/errors-in-join.config.ts
@@ -1,0 +1,66 @@
+import { WeavingConfig } from '../../../src/config/weaving-config';
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
+import { ASTNode, GraphQLError, GraphQLResolveInfo, ObjectValueNode } from 'graphql';
+import { compact } from '../../../src/utils/utils';
+
+export async function getConfig(): Promise<WeavingConfig> {
+    const typeDefs = gql`
+        type Query {
+            locations(filter: LocationFilter): [Location]
+            events: [Event]
+        }
+
+        type Event {
+            location: String
+        }
+
+        type Location {
+            name: String
+        }
+
+        input LocationFilter {
+            names: [String]
+        }
+    `;
+
+    const schema = makeExecutableSchema({
+        typeDefs,
+        resolvers: {
+            Query: {
+                locations(source, args, context, info: GraphQLResolveInfo) {
+                    // note: we can't really test if the locations are properly propagated because, apart from the
+                    // selection set, no nodes are passed from the original query to this join-data query.
+                    // error locations within the selection sets are tested in errors-in-link.
+                    throw new GraphQLError(`Runtime error in Query.locations`);
+                },
+                events() {
+                    return ['Berlin', 'Stuttgart', 'Munich'].map(location => ({location}));
+                }
+            }
+        }
+    });
+
+    return {
+        endpoints: [
+            {
+                schema,
+                fieldMetadata: {
+                    'Event.location': {
+                        link: {
+                            field: 'locations',
+                            argument: 'filter.names',
+                            batchMode: true,
+                            keyField: 'name'
+                        }
+                    },
+                    'Query.events': {
+                        join: {
+                            linkField: 'location'
+                        }
+                    }
+                }
+            }
+        ]
+    };
+}

--- a/spec/regression/data/errors-in-join.graphql
+++ b/spec/regression/data/errors-in-join.graphql
@@ -1,0 +1,7 @@
+{
+    events {
+        location {
+            name
+        }
+    }
+}

--- a/spec/regression/data/errors-in-join.result.json
+++ b/spec/regression/data/errors-in-join.result.json
@@ -1,0 +1,19 @@
+{
+  "errors": [
+    {
+      "message": "Field \"locations\" reported error: Runtime error in Query.locations",
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ],
+      "path": [
+        "events"
+      ]
+    }
+  ],
+  "data": {
+    "events": null
+  }
+}

--- a/spec/regression/data/errors-in-link.result.json
+++ b/spec/regression/data/errors-in-link.result.json
@@ -16,7 +16,7 @@
       ]
     },
     {
-      "message": "Argument \"name\" has invalid value \"Marie-Louise\".\nExpected type \"Name\", found \"Marie-Louise\".",
+      "message": "Field \"ns1.horst\" reported error: Argument \"name\" has invalid value \"Marie-Louise\".\nExpected type \"Name\", found \"Marie-Louise\".",
       "locations": [
         {
           "line": 28,
@@ -30,7 +30,7 @@
       ]
     },
     {
-      "message": "GraphQL error at line 39, column 47:\nArgument \"name\" has invalid value \"Marie-Louise\".\nExpected type \"Name\", found \"Marie-Louise\".\n\nGraphQL error at line 40, column 47:\nArgument \"name\" has invalid value \"Marie-Louise\".\nExpected type \"Name\", found \"Marie-Louise\".",
+      "message": "Field \"ns1.horst\" reported error: GraphQL error at line 39, column 47:\nArgument \"name\" has invalid value \"Marie-Louise\".\nExpected type \"Name\", found \"Marie-Louise\".\n\nGraphQL error at line 40, column 47:\nArgument \"name\" has invalid value \"Marie-Louise\".\nExpected type \"Name\", found \"Marie-Louise\".",
       "locations": [
         {
           "line": 37,
@@ -44,7 +44,7 @@
       ]
     },
     {
-      "message": "Variable \"$name\" got invalid value \"Hans-Joachim\".\nExpected type \"Name\", found \"Hans-Joachim\": I don't like this name: Hans-Joachim",
+      "message": "Field \"ns1.horst\" reported error: Variable \"$name\" got invalid value \"Hans-Joachim\".\nExpected type \"Name\", found \"Hans-Joachim\": I don't like this name: Hans-Joachim",
       "locations": [
         {
           "line": 15,
@@ -72,7 +72,7 @@
       ]
     },
     {
-      "message": "No horst by name",
+      "message": "Field \"ns1.horstByNameBroken\" reported error: No horst by name",
       "locations": [
         {
           "line": 49,

--- a/spec/regression/helpers.ts
+++ b/spec/regression/helpers.ts
@@ -13,3 +13,10 @@ export async function testConfigWithQuery(proxyConfig: WeavingConfig, query: str
     const schema = await weaveSchemas(proxyConfig);
     return graphql(schema, query, {cariedOnRootValue: true}, {}, variableValues, undefined);
 }
+
+export function normalizeJSON(value: any) {
+    if (value === undefined) {
+        return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+}

--- a/spec/regression/regressions.spec.ts
+++ b/spec/regression/regressions.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
-import {graphql} from "graphql";
-import {testConfigWithQuery} from "./helpers";
+import { graphql, GraphQLError } from 'graphql';
+import { normalizeJSON, testConfigWithQuery } from './helpers';
 import {TO_EQUAL_JSON_MATCHERS} from "../helpers/equal-json";
 import {GraphQLHTTPTestEndpoint} from "../helpers/grapqhl-http-test/graphql-http-test-endpoint";
 
@@ -34,11 +34,15 @@ describe('regression tests', () => {
             const variableValues = fs.existsSync(variablesPath) ? JSON.parse(fs.readFileSync(variablesPath, 'utf-8')) : {};
             const result = await testConfigWithQuery(await configFile.getConfig(), queryString, variableValues);
 
-            if (saveActualAsExpected && !(jasmine as any).matchersUtil.equals(result, expectedResult)) {
-                fs.writeFileSync(resultPath, JSON.stringify(result, undefined, '  '), 'utf-8');
+            if (saveActualAsExpected) {
+                const equals = (jasmine as any).matchersUtil.equals;
+                if (!equals(result.data, expectedResult.data) || !equals(sortAndNormalizeErrors(result.errors), sortAndNormalizeErrors(expectedResult.errors))) {
+                    fs.writeFileSync(resultPath, JSON.stringify(result, undefined, '  '), 'utf-8');
+                }
             }
 
-            (<any>expect(result)).toEqualJSON(expectedResult);
+            (<any>expect(result.data)).toEqualJSON(expectedResult.data);
+            (<any>expect(sortAndNormalizeErrors(result.errors))).toEqualJSON(sortAndNormalizeErrors(expectedResult.errors));
         });
     }
 
@@ -47,3 +51,32 @@ describe('regression tests', () => {
     })
 
 });
+
+function sortAndNormalizeErrors(errors: GraphQLError[]|undefined) {
+    if (!errors || !errors.length) {
+        return errors;
+    }
+    return errors.map(err => normalizeJSON(err)).sort(compareErrors);
+}
+
+function compareErrors(a: GraphQLError, b: GraphQLError) {
+    const path1 = a.path ? a.path.join('.') : undefined;
+    const path2 = b.path ? b.path.join('.') : undefined;
+    if (path1 && path2) {
+        if (path1 < path2) {
+            return -1;
+        }
+        if (path1 > path2) {
+            return 1;
+        }
+    }
+    const json1 = JSON.stringify(a);
+    const json2 = JSON.stringify(a);
+    if (json1 < json2) {
+        return -1;
+    }
+    if (json1 > json2) {
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Now, fields reported from the target field of a link are properly reported. Previously, the `FieldErrorValue` was used as regular value. We now also prefix the error messages so that it becomes clear the error originates from the link target.