### PR TITLE
Fix scalar type implementations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,15 @@
       "integrity": "sha512-s7w/gfCoD3+IwiGsfn/VGu7XSX0bwv/HA9sU9NmdRwKzx4R8s9u7mqmGRGOcxRzzNEpy93Zv9PK+sZbFNdQ5fg==",
       "dev": true
     },
+    "@types/graphql-type-json": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@types/graphql-type-json/-/graphql-type-json-0.1.2.tgz",
+      "integrity": "sha512-2c8/x838/jX89Hi/uzgeVBN8n4JGSvlWNZJRJ7lo1qeDj2zLCMZSGejOMpdBs9+KB4ja3tPWGQaGkQ6P5N5Etw==",
+      "dev": true,
+      "requires": {
+        "@types/graphql": "0.11.5"
+      }
+    },
     "@types/jasmine": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.6.0.tgz",
@@ -636,6 +645,11 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/graphql-transformer/-/graphql-transformer-0.1.3.tgz",
       "integrity": "sha512-TE9ddaC6t0NDkbvffnTWbxaC9NHB9T4LinamsftLMj6k8xUxuQVjd9B4Hr0n4i4/m35oQ7Fkdu4vf4ppWH0s7g=="
+    },
+    "graphql-type-json": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.1.4.tgz",
+      "integrity": "sha1-ifE/XTLOCMmnbHn9+cGWg4TYGk4="
     },
     "has-ansi": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/cors": "^2.8.1",
     "@types/fs-extra": "^3.0.2",
     "@types/graphql": "^0.11.5",
+    "@types/graphql-type-json": "^0.1.2",
     "@types/jasmine": "^2.5.52",
     "@types/node": "^7.0.22",
     "@types/node-fetch": "^1.6.7",
@@ -50,6 +51,7 @@
   "dependencies": {
     "dataloader": "~1.3.0",
     "graphql-transformer": "^0.1.3",
+    "graphql-type-json": "^0.1.4",
     "line-column": "^1.0.2",
     "node-fetch": "~1.7.0",
     "trace-error": "~0.0.7"

--- a/spec/helpers/non-negative-int.ts
+++ b/spec/helpers/non-negative-int.ts
@@ -1,0 +1,21 @@
+import { isNumber } from "util";
+import { GraphQLScalarType } from 'graphql';
+
+export const NonNegativeInt = new GraphQLScalarType({
+    name: 'NonNegativeInt',
+    parseValue(value) {
+        if (!isNumber(value) || !isFinite(value) || value < 0) {
+            throw new TypeError('Not a non-negative integer: ' + value);
+        }
+        return value;
+    },
+    serialize(value) {
+        return parseInt(value);
+    },
+    parseLiteral(valueNode) {
+        if (valueNode.kind == 'IntValue' && parseInt(valueNode.value) >= 0) {
+            return parseInt(valueNode.value);
+        }
+        return null;
+    }
+});

--- a/spec/regression/data/scalar-as-link-key.config.ts
+++ b/spec/regression/data/scalar-as-link-key.config.ts
@@ -1,0 +1,66 @@
+import { WeavingConfig } from '../../../src/config/weaving-config';
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
+import { NonNegativeInt } from '../../helpers/non-negative-int';
+
+export async function getConfig(): Promise<WeavingConfig> {
+
+    const typeDefs = gql`
+        type Query {
+            locations(filter: LocationFilter): [Location]
+            events: [Event]
+        }
+        
+        type Event {
+            location: NonNegativeInt
+        }
+        
+        type Location {
+            id: NonNegativeInt
+        }
+        
+        input LocationFilter {
+            ids: [NonNegativeInt]
+        }
+        
+        scalar NonNegativeInt
+    `;
+
+    const schema = makeExecutableSchema({
+        typeDefs,
+        resolvers: {
+            NonNegativeInt,
+            Query: {
+                locations(source, args) {
+                    return args.filter.ids.map((id: number) => ({ id }));
+                },
+                events() {
+                    return [ { location: 0, }, { location: 1 }, { location: null }]
+                }
+            }
+        }
+    });
+
+    return {
+        endpoints: [
+            {
+                schema,
+                fieldMetadata: {
+                    'Event.location': {
+                        link: {
+                            field: 'locations',
+                            argument: 'filter.ids',
+                            batchMode: true,
+                            keyField: 'id'
+                        }
+                    },
+                    'Query.events': {
+                        join: {
+                            linkField: 'location'
+                        }
+                    }
+                }
+            }
+        ]
+    };
+}

--- a/spec/regression/data/scalar-as-link-key.graphql
+++ b/spec/regression/data/scalar-as-link-key.graphql
@@ -1,0 +1,13 @@
+{
+    events {
+        location {
+            id
+        }
+    }
+
+    events_loc_0: events(filter: { location: { ids: [ 0 ] } }) {
+        location {
+            id
+        }
+    }
+}

--- a/spec/regression/data/scalar-as-link-key.result.json
+++ b/spec/regression/data/scalar-as-link-key.result.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "events": [
+      {
+        "location": {
+          "id": 0
+        }
+      },
+      {
+        "location": {
+          "id": 1
+        }
+      },
+      {
+        "location": null
+      }
+    ],
+    "events_loc_0": [
+      {
+        "location": {
+          "id": 0
+        }
+      }
+    ]
+  }
+}

--- a/spec/regression/data/scalar-in-filter.config.ts
+++ b/spec/regression/data/scalar-in-filter.config.ts
@@ -1,0 +1,74 @@
+import { WeavingConfig } from '../../../src/config/weaving-config';
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
+import { NonNegativeInt } from '../../helpers/non-negative-int';
+
+export async function getConfig(): Promise<WeavingConfig> {
+    const typeDefs = gql`
+        type Query {
+            locations(filter: LocationFilter): [Location]
+            events(filter: EventFilter): [Event]
+        }
+
+        type Event {
+            location: String
+            eventFilterValue: NonNegativeInt
+        }
+
+        type Location {
+            name: String
+            locationFilterValue: NonNegativeInt
+        }
+
+        input LocationFilter {
+            names: [String]
+            locationFilterValue: NonNegativeInt
+        }
+
+        input EventFilter {
+            eventFilterValue: NonNegativeInt
+        }
+
+        scalar NonNegativeInt
+    `;
+
+    const schema = makeExecutableSchema({
+        typeDefs,
+        resolvers: {
+            NonNegativeInt,
+            Query: {
+                locations(source, args) {
+                    const locationFilterValue = args.filter.locationFilterValue;
+                    return args.filter.names.map((name: string) => ({name, locationFilterValue}));
+                },
+                events(source, args) {
+                    const eventFilterValue = args.filter.eventFilterValue;
+                    return ['Berlin', 'Stuttgart', 'Munich'].map(location => ({location, eventFilterValue}));
+                }
+            }
+        }
+    });
+
+    return {
+        endpoints: [
+            {
+                schema,
+                fieldMetadata: {
+                    'Event.location': {
+                        link: {
+                            field: 'locations',
+                            argument: 'filter.names',
+                            batchMode: true,
+                            keyField: 'name'
+                        }
+                    },
+                    'Query.events': {
+                        join: {
+                            linkField: 'location'
+                        }
+                    }
+                }
+            }
+        ]
+    };
+}

--- a/spec/regression/data/scalar-in-filter.graphql
+++ b/spec/regression/data/scalar-in-filter.graphql
@@ -1,0 +1,41 @@
+fragment eventFrag on Event {
+    location {
+        name
+        locationFilterValue
+    }
+    eventFilterValue
+}
+
+query q($zero: NonNegativeInt, $null: NonNegativeInt, $one: NonNegativeInt) {
+    events_1_1: events(filter: { eventFilterValue: 1, location: { locationFilterValue: 1 }}) {
+        ...eventFrag
+    }
+
+    events_0_0: events(filter: { eventFilterValue: 0, location: { locationFilterValue: 0 }}) {
+        ...eventFrag
+    }
+
+    events_null_null: events(filter: { eventFilterValue: null, location: { locationFilterValue: null }}) {
+        ...eventFrag
+    }
+
+    events_1_1_var: events(filter: { eventFilterValue: $one, location: { locationFilterValue: $one }}) {
+        ...eventFrag
+    }
+
+    events_0_0_var: events(filter: { eventFilterValue: $zero, location: { locationFilterValue: $zero }}) {
+        ...eventFrag
+    }
+
+    events_null_null_var: events(filter: { eventFilterValue: $null, location: { locationFilterValue: $null }}) {
+        ...eventFrag
+    }
+
+    events_0_neg1: events(filter: { eventFilterValue: 0, location: { locationFilterValue: -1 }}) {
+        ...eventFrag
+    }
+
+    events_neg1_neg1: events(filter: { eventFilterValue: -1, location: { locationFilterValue: -1 }}) {
+        ...eventFrag
+    }
+}

--- a/spec/regression/data/scalar-in-filter.result.json
+++ b/spec/regression/data/scalar-in-filter.result.json
@@ -1,0 +1,170 @@
+{
+  "errors": [
+    {
+      "message": "Argument \"filter\" has invalid value {eventFilterValue: -1}.\nIn field \"eventFilterValue\": Expected type \"NonNegativeInt\", found -1.",
+      "locations": [
+        {
+          "line": 38,
+          "column": 38
+        }
+      ],
+      "path": [
+        "events_neg1_neg1"
+      ]
+    },
+    {
+      "message": "Field \"locations\" reported error: Variable \"$locationFilter\" got invalid value {\"names\":[\"Berlin\",\"Stuttgart\",\"Munich\"],\"locationFilterValue\":-1}.\nIn field \"locationFilterValue\": Expected type \"NonNegativeInt\", found -1: Not a non-negative integer: -1",
+      "locations": [
+        {
+          "line": 34,
+          "column": 5
+        }
+      ],
+      "path": [
+        "events_0_neg1"
+      ]
+    }
+  ],
+  "data": {
+    "events_1_1": [
+      {
+        "location": {
+          "name": "Berlin",
+          "locationFilterValue": 1
+        },
+        "eventFilterValue": 1
+      },
+      {
+        "location": {
+          "name": "Stuttgart",
+          "locationFilterValue": 1
+        },
+        "eventFilterValue": 1
+      },
+      {
+        "location": {
+          "name": "Munich",
+          "locationFilterValue": 1
+        },
+        "eventFilterValue": 1
+      }
+    ],
+    "events_0_0": [
+      {
+        "location": {
+          "name": "Berlin",
+          "locationFilterValue": 0
+        },
+        "eventFilterValue": 0
+      },
+      {
+        "location": {
+          "name": "Stuttgart",
+          "locationFilterValue": 0
+        },
+        "eventFilterValue": 0
+      },
+      {
+        "location": {
+          "name": "Munich",
+          "locationFilterValue": 0
+        },
+        "eventFilterValue": 0
+      }
+    ],
+    "events_null_null": [
+      {
+        "location": {
+          "name": "Berlin",
+          "locationFilterValue": null
+        },
+        "eventFilterValue": null
+      },
+      {
+        "location": {
+          "name": "Stuttgart",
+          "locationFilterValue": null
+        },
+        "eventFilterValue": null
+      },
+      {
+        "location": {
+          "name": "Munich",
+          "locationFilterValue": null
+        },
+        "eventFilterValue": null
+      }
+    ],
+    "events_1_1_var": [
+      {
+        "location": {
+          "name": "Berlin",
+          "locationFilterValue": 1
+        },
+        "eventFilterValue": 1
+      },
+      {
+        "location": {
+          "name": "Stuttgart",
+          "locationFilterValue": 1
+        },
+        "eventFilterValue": 1
+      },
+      {
+        "location": {
+          "name": "Munich",
+          "locationFilterValue": 1
+        },
+        "eventFilterValue": 1
+      }
+    ],
+    "events_0_0_var": [
+      {
+        "location": {
+          "name": "Berlin",
+          "locationFilterValue": 0
+        },
+        "eventFilterValue": 0
+      },
+      {
+        "location": {
+          "name": "Stuttgart",
+          "locationFilterValue": 0
+        },
+        "eventFilterValue": 0
+      },
+      {
+        "location": {
+          "name": "Munich",
+          "locationFilterValue": 0
+        },
+        "eventFilterValue": 0
+      }
+    ],
+    "events_null_null_var": [
+      {
+        "location": {
+          "name": "Berlin",
+          "locationFilterValue": null
+        },
+        "eventFilterValue": null
+      },
+      {
+        "location": {
+          "name": "Stuttgart",
+          "locationFilterValue": null
+        },
+        "eventFilterValue": null
+      },
+      {
+        "location": {
+          "name": "Munich",
+          "locationFilterValue": null
+        },
+        "eventFilterValue": null
+      }
+    ],
+    "events_0_neg1": null,
+    "events_neg1_neg1": null
+  }
+}

--- a/spec/regression/data/scalar-in-filter.vars.json
+++ b/spec/regression/data/scalar-in-filter.vars.json
@@ -1,0 +1,5 @@
+{
+  "one": 1,
+  "zero": 0,
+  "null": null
+}

--- a/spec/regression/data/scalars.config.ts
+++ b/spec/regression/data/scalars.config.ts
@@ -1,0 +1,47 @@
+import { GraphQLInt, GraphQLObjectType, GraphQLScalarType, GraphQLSchema, GraphQLUnionType } from 'graphql';
+import {testTypes} from "../../helpers/test-types";
+import { WeavingConfig } from '../../../src/config/weaving-config';
+import { isNumber } from "util";
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
+import { NonNegativeInt } from '../../helpers/non-negative-int';
+
+export async function getConfig(): Promise<WeavingConfig> {
+    function defaultIfNull<T>(value: T|undefined, defaultValue: T): T {
+        if (value == undefined) {
+            return defaultValue;
+        }
+        return value;
+    }
+
+    const typeDefs = gql`
+        type Query {
+            sum(lhs: NonNegativeInt, rhs: NonNegativeInt): NonNegativeInt
+        }
+        
+        scalar NonNegativeInt
+    `;
+
+    const schema = makeExecutableSchema({
+        typeDefs,
+        resolvers: {
+            NonNegativeInt,
+            Query: {
+                sum(source, args) {
+                    if (args.lhs == undefined && args.rhs == undefined) {
+                        return undefined;
+                    }
+                    return defaultIfNull(args.lhs, 0) + defaultIfNull(args.rhs, 0)
+                }
+            }
+        }
+    });
+
+    return {
+        endpoints: [
+            {
+                schema
+            }
+        ]
+    };
+}

--- a/spec/regression/data/scalars.graphql
+++ b/spec/regression/data/scalars.graphql
@@ -1,0 +1,14 @@
+query q($zero: NonNegativeInt, $null: NonNegativeInt, $one: NonNegativeInt){
+    sum_0_0: sum(lhs: 0, rhs: 0)
+    sum_1_0: sum(lhs: 1, rhs: 0)
+    sum_null_2: sum(lhs: null, rhs: 2)
+    sum_null_0: sum(lhs: null, rhs: 0)
+    sum_null_null: sum(lhs: null, rhs: null)
+    sum_neg1_null: sum(lhs: -1, rhs: 0)
+
+    sum_0_0_var: sum(lhs: $zero, rhs: $zero)
+    sum_1_0_var: sum(lhs: $one, rhs: $zero)
+    sum_null_1_var: sum(lhs: $null, rhs: $one)
+    sum_null_0_var: sum(lhs: $null, rhs: $zero)
+    sum_null_null_var: sum(lhs: $null, rhs: $null)
+}

--- a/spec/regression/data/scalars.result.json
+++ b/spec/regression/data/scalars.result.json
@@ -1,0 +1,29 @@
+{
+  "errors": [
+    {
+      "message": "Argument \"lhs\" has invalid value -1.\nExpected type \"NonNegativeInt\", found -1.",
+      "locations": [
+        {
+          "line": 7,
+          "column": 29
+        }
+      ],
+      "path": [
+        "sum_neg1_null"
+      ]
+    }
+  ],
+  "data": {
+    "sum_0_0": 0,
+    "sum_1_0": 1,
+    "sum_null_2": 2,
+    "sum_null_0": 0,
+    "sum_null_null": null,
+    "sum_neg1_null": null,
+    "sum_0_0_var": 0,
+    "sum_1_0_var": 1,
+    "sum_null_1_var": 1,
+    "sum_null_0_var": 0,
+    "sum_null_null_var": null
+  }
+}

--- a/spec/regression/data/scalars.vars.json
+++ b/spec/regression/data/scalars.vars.json
@@ -1,0 +1,5 @@
+{
+  "one": 1,
+  "zero": 0,
+  "null": null
+}

--- a/src/pipeline/custom-scalar-types-serialization.ts
+++ b/src/pipeline/custom-scalar-types-serialization.ts
@@ -1,6 +1,7 @@
 import { PipelineModule } from './pipeline-module';
 import { GraphQLScalarType } from 'graphql';
 import { SchemaTransformer } from 'graphql-transformer';
+import GraphQLJSON = require('graphql-type-json');
 
 /**
  * Overwrite the default behaviour from generateClientSchema which sets values of custom scalar types to false.
@@ -17,18 +18,13 @@ export class CustomScalarTypesSerializationModule implements PipelineModule {
 export class CustomScalarTypesSerializationTransformer implements SchemaTransformer {
 
     transformScalarType(type: GraphQLScalarType): GraphQLScalarType {
+        // parseLiteral needs to parse all possible InputValues to its corresponding JSON value. the JSON scalar
+        // implementation does exactly. this. parseLiteral and serialize are the identity function.
         return {
             ...type,
-            parseValue: parseValue,
-            parseLiteral: parseLiteral
+            parseValue: (value) => GraphQLJSON.parseValue(value),
+            parseLiteral: (value) => GraphQLJSON.parseLiteral(value),
+            serialize: (value) => GraphQLJSON.serialize(value)
         } as GraphQLScalarType;
     }
-}
-
-function parseValue(value: any) {
-    return value || false;
-}
-
-function parseLiteral(value: any) {
-    return value || false;
 }

--- a/src/pipeline/helpers/link-helpers.ts
+++ b/src/pipeline/helpers/link-helpers.ts
@@ -384,7 +384,9 @@ export function getKeyType(config: { linkConfig: LinkConfig, linkFieldType: Grap
     if (!(argumentType instanceof GraphQLScalarType)) {
         throw new WeavingError(`Type of argument field ${JSON.stringify(config.linkConfig.argument)} must be scalar type or list/non-null-type of a scalar type, but is ${argumentType}`);
     }
-    if (argumentType != linkKeyType) {
+    // comparing the names here. Can't use reference equality on the types because mapped and unmapped types are confused here.
+    // We don't rename scalars in this module, so this is fine
+    if (argumentType.name != linkKeyType.name) {
         config.reportError(new WeavingError(`Link field ${JSON.stringify(config.linkFieldName)} is of type ${linkKeyType}, but argument ${JSON.stringify(config.linkConfig.argument)} on target field ${JSON.stringify(config.linkConfig.field)} has type ${argumentType}`));
     }
 


### PR DESCRIPTION
parseLiteral() should create a JSON value from a ValueNode; parseValue should validate and coerce a JSON value. Since we just want to pass the values through to the underlying endpoint, we use a JSON type implementation that does exactly this.

Fixes #20.