### PR TITLE
Keep original fields if @link config fails

### DIFF
--- a/spec/regression/data/endpoint-schema-errors-continue.config.ts
+++ b/spec/regression/data/endpoint-schema-errors-continue.config.ts
@@ -3,12 +3,25 @@ import { GraphQLClient } from '../../../src/graphql-client/graphql-client';
 import { ExecutionResult } from 'graphql';
 import { defaultTestSchema } from '../../helpers/grapqhl-http-test/graphql-http-test-schema';
 import { WeavingErrorHandlingMode } from '../../../src/config/error-handling';
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
 
 const errorClient: GraphQLClient = {
     execute(query, vars, context, introspection): Promise<ExecutionResult> {
         throw new Error(introspection ? 'Throwing introspection' : 'Throwing query');
     }
 };
+
+const normalSchema = makeExecutableSchema({
+    typeDefs: gql`type Query { field: String }`,
+    resolvers: {
+        Query: {
+            field() {
+                return 'hello';
+            }
+        }
+    }
+});
 
 export async function getConfig(): Promise<WeavingConfig> {
     return {
@@ -30,7 +43,21 @@ export async function getConfig(): Promise<WeavingConfig> {
                 namespace: 'working',
                 typePrefix: 'Working',
                 schema: defaultTestSchema
-            }
+            },
+            {
+                namespace: 'linkConfigError',
+                typePrefix: 'LinkConfigError',
+                schema: normalSchema,
+                fieldMetadata: {
+                    'Query.field': {
+                        link: {
+                            field: 'nonexisting',
+                            argument: 'id',
+                            batchMode: false
+                        }
+                    }
+                }
+            },
         ],
         errorHandling: WeavingErrorHandlingMode.CONTINUE
     };

--- a/spec/regression/data/endpoint-schema-errors-continue.graphql
+++ b/spec/regression/data/endpoint-schema-errors-continue.graphql
@@ -9,4 +9,8 @@
             description
         }
     }
+    # assert that link config errors do not remove the field but just leave it as-is without linking
+    linkConfigError {
+        field
+    }
 }

--- a/spec/regression/data/endpoint-schema-errors-continue.result.json
+++ b/spec/regression/data/endpoint-schema-errors-continue.result.json
@@ -6,6 +6,9 @@
           "name": "working"
         },
         {
+          "name": "linkConfigError"
+        },
+        {
           "name": "_extIntrospection"
         }
       ]
@@ -14,6 +17,9 @@
       "Country": {
         "description": "Deutschland"
       }
+    },
+    "linkConfigError": {
+      "field": "hello"
     }
   }
 }

--- a/src/pipeline/links.ts
+++ b/src/pipeline/links.ts
@@ -401,6 +401,7 @@ class SchemaLinkTransformer implements ExtendedSchemaTransformer {
     transformFields(fields: GraphQLFieldConfigMapWithMetadata, context: FieldsTransformationContext): GraphQLFieldConfigMapWithMetadata {
         const newFields: GraphQLFieldConfigMapWithMetadata = {};
         for (const [name, fieldConfig] of objectEntries(fields)) {
+            let handledSuccessfully = false;
             if (fieldConfig.metadata && fieldConfig.metadata.link && !fieldConfig.metadata.link.ignore) {
                 const linkConfig = fieldConfig.metadata.link;
                 nestErrorHandling(this.reportError, `Error in @link config on ${context.oldOuterType.name}.${name}`, (reportError) => {
@@ -429,8 +430,12 @@ class SchemaLinkTransformer implements ExtendedSchemaTransformer {
                             }
                         }
                     };
+                    handledSuccessfully = true;
                 });
-            } else {
+            }
+
+            // if no link config found, or link preparation threw an error, just keep the old field
+            if (!handledSuccessfully) {
                 newFields[name] = fieldConfig;
             }
         }


### PR DESCRIPTION
Previously, this removed the field and might have caused an error if no fields were left in an object type.