### PR TITLE
Fix error handling of missing link field in join config

### DIFF
--- a/spec/regression/data/endpoint-schema-errors-continue.graphql
+++ b/spec/regression/data/endpoint-schema-errors-continue.graphql
@@ -11,6 +11,17 @@
     }
     # assert that link config errors do not remove the field but just leave it as-is without linking
     linkConfigError {
-        field
+        inner {
+            field
+        }
+    }
+    # assert that join config errors do not remove the field but just leave it as-is without joining
+    joinConfigError {
+        inners {
+            field
+        }
+    }
+    _errors {
+        message
     }
 }

--- a/spec/regression/data/endpoint-schema-errors-continue.result.json
+++ b/spec/regression/data/endpoint-schema-errors-continue.result.json
@@ -9,7 +9,13 @@
           "name": "linkConfigError"
         },
         {
+          "name": "joinConfigError"
+        },
+        {
           "name": "_extIntrospection"
+        },
+        {
+          "name": "_errors"
         }
       ]
     },
@@ -19,7 +25,39 @@
       }
     },
     "linkConfigError": {
-      "field": "hello"
-    }
+      "inner": {
+        "field": "hello"
+      }
+    },
+    "joinConfigError": {
+      "inners": [
+        {
+          "field": "hello"
+        },
+        {
+          "field": "world"
+        }
+      ]
+    },
+    "_errors": [
+      {
+        "message": "Failed to retrieve schema: Throwing introspection"
+      },
+      {
+        "message": "Failed to retrieve schema: Throwing introspection"
+      },
+      {
+        "message": "Failed to retrieve schema: Throwing introspection"
+      },
+      {
+        "message": "Error in @link config on LinkConfigErrorZInner.field: Target field \"nonexisting\" does not exist"
+      },
+      {
+        "message": "Error in @join config on inners: Link defines target field as \"nonexisting\" which does not exist"
+      },
+      {
+        "message": "Error in @link config on joinConfigErrorZInner.field: Target field \"nonexisting\" does not exist"
+      }
+    ]
   }
 }

--- a/src/pipeline/links.ts
+++ b/src/pipeline/links.ts
@@ -547,7 +547,7 @@ class SchemaLinkTransformer implements ExtendedSchemaTransformer {
             throw new WeavingError(`Link specifies oneToMany, but @join does not support one-to-many links.`);
         }
         const {fieldPath: targetFieldPath, field: targetField} = parseLinkTargetPath(linkConfig.field, this.schema.schema) ||
-        throwError(`Link defines target field as ${JSON.stringify(linkConfig.field)} which does not exist`);
+        throwError(() => new WeavingError(`Link defines target field as ${JSON.stringify(linkConfig.field)} which does not exist`));
 
         if (isListType(linkField.type)) {
             throw new WeavingError(`@join not available for linkFields with array type`);


### PR DESCRIPTION
Previously, this threw an error while weaving. Now, it is reported as a regular weaving error and can be handled via the errorHandling policy.