### PR TITLE
Implement "skip" argument for join fields

### DIFF
--- a/spec/helpers/grapqhl-http-test/graphql-http-test-schema.ts
+++ b/spec/helpers/grapqhl-http-test/graphql-http-test-schema.ts
@@ -58,6 +58,9 @@ export const defaultTestSchema = new GraphQLSchema({
                     if (args.orderBy) {
                         countries = [...countries].sort(comparator(args.orderBy));
                     }
+                    if (args.skip) {
+                        countries = countries.slice(args.skip);
+                    }
                     if (args.first) {
                         countries = countries.slice(0, args.first /* exclusive end */);
                     }
@@ -71,6 +74,7 @@ export const defaultTestSchema = new GraphQLSchema({
                     orderBy: {type: testTypes.countryOrderType},
                     last: {type: GraphQLInt},
                     first: {type: GraphQLInt},
+                    skip: {type: GraphQLInt},
                     useLargeList: {type: GraphQLBoolean}
                 }
             },
@@ -103,6 +107,9 @@ export const defaultTestSchema = new GraphQLSchema({
                     if (args.orderBy) {
                         people = [...people].sort(comparator(args.orderBy));
                     }
+                    if (args.skip) {
+                        people = people.slice(args.skip);
+                    }
                     if (args.first) {
                         people = people.slice(0, args.first /* exclusive end */);
                     }
@@ -116,6 +123,7 @@ export const defaultTestSchema = new GraphQLSchema({
                     orderBy: {type: testTypes.personOrderType},
                     last: {type: GraphQLInt},
                     first: {type: GraphQLInt},
+                    skip: {type: GraphQLInt},
                     nationality: {type: GraphQLString}
                 }
             }

--- a/spec/regression/data/join-with-skip.config.ts
+++ b/spec/regression/data/join-with-skip.config.ts
@@ -1,0 +1,27 @@
+import { WeavingConfig } from '../../../src/config/weaving-config';
+
+export async function getConfig(): Promise<WeavingConfig> {
+    return {
+        endpoints: [
+            {
+                url: "http://localhost:1337/graphql",
+                fieldMetadata: {
+                    'Person.nationality': {
+                        link: {
+                            field: "allCountries",
+                            argument: "filter.identCode_in",
+                            keyField: "identCode",
+                            batchMode: true
+                        }
+                    },
+
+                    'Query.allPeople': {
+                        join: {
+                            linkField: 'nationality'
+                        }
+                    }
+                }
+            }
+        ]
+    };
+}

--- a/spec/regression/data/join-with-skip.graphql
+++ b/spec/regression/data/join-with-skip.graphql
@@ -1,0 +1,18 @@
+query {
+  skip: allPeople(skip: 1, first: 1) {
+    name
+  }
+  skipWithRightOrder: allPeople(skip: 1, first: 1, orderBy: nationality_description_ASC) {
+    name
+  }
+  skipWithRightFilter: allPeople(skip: 1, first: 1, filter: { nationality: { continent: Europe }}) {
+    name
+  }
+  skipWithRightFilterAndOrder: allPeople(skip: 1, first: 1, filter: { nationality: { continent: Europe }}, orderBy: nationality_description_DESC) {
+    name
+  }
+  # triggers an optimization
+  skipWithOnlyOnePerCountry: allPeople(skip: 1, first: 1, filter: { isCool: true, nationality: { continent: Europe } }, orderBy: nationality_description_DESC) {
+    name
+  }
+}

--- a/spec/regression/data/join-with-skip.result.json
+++ b/spec/regression/data/join-with-skip.result.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "skip": [
+      {"name": "Helga"}
+    ],
+    "skipWithRightOrder": [
+      {"name": "Yin"}
+    ],
+    "skipWithRightFilter": [
+      {"name": "Helga"}
+    ],
+    "skipWithRightFilterAndOrder": [
+      {"name": "Horst"}
+    ],
+    "skipWithOnlyOnePerCountry": [
+      {"name": "Horst"}
+    ]
+  }
+}

--- a/spec/regression/data/join.graphql
+++ b/spec/regression/data/join.graphql
@@ -1,4 +1,4 @@
-query ($orderBy: CountryNSPersonWithCountryNSCountryJoinedOrderBy, $leftOrderBy: CountryNSPersonWithCountryNSCountryJoinedOrderBy, $nullFilter: CountryNSPersonWithCountryNSCountryJoinedFilter, $nullOrderBy: CountryNSPersonWithCountryNSCountryJoinedOrderBy, $nullFirst: Int){
+query ($orderBy: CountryNSPersonWithCountryNSCountryJoinedOrderBy, $leftOrderBy: CountryNSPersonWithCountryNSCountryJoinedOrderBy, $nullFilter: CountryNSPersonWithCountryNSCountryJoinedFilter, $nullOrderBy: CountryNSPersonWithCountryNSCountryJoinedOrderBy, $nullFirst: Int) {
   staticData {
     allPeople {
       name

--- a/spec/regression/regressions.spec.ts
+++ b/spec/regression/regressions.spec.ts
@@ -22,7 +22,7 @@ describe('regression tests', () => {
     const saveActualAsExpected = process.argv.includes('--save-actual-as-expected');
 
     for (const fileName of files) {
-        if (!fileName.startsWith('errors')) {
+        if (!fileName.startsWith('join')) {
             continue;
         }
         if (!fileName.endsWith('.graphql')) {

--- a/src/pipeline/helpers/link-helpers.ts
+++ b/src/pipeline/helpers/link-helpers.ts
@@ -20,6 +20,7 @@ import { WeavingError, WeavingErrorConsumer } from '../../config/errors';
 export const FILTER_ARG = 'filter';
 export const ORDER_BY_ARG = 'orderBy';
 export const FIRST_ARG = 'first';
+export const SKIP_ARG = 'skip';
 
 export function parseLinkTargetPath(path: string, schema: GraphQLSchema): { field: GraphQLField<any, any>, fieldPath: string[] } | undefined {
     const fieldPath = path.split('.');
@@ -266,6 +267,7 @@ export async function fetchJoinedObjects(params: {
     additionalFilter: any,
     orderBy?: string,
     first?: number,
+    skip?: number,
     filterType: GraphQLInputType,
     keyType: GraphQLScalarType,
     linkConfig: LinkConfig,
@@ -343,6 +345,21 @@ export async function fetchJoinedObjects(params: {
             }
         };
         args = [...args, firstArg];
+    }
+
+    if (params.skip) {
+        const skipArg: ArgumentNode = {
+            kind: 'Argument',
+            name: {
+                kind: 'Name',
+                value: SKIP_ARG
+            },
+            value: {
+                kind: 'IntValue',
+                value: params.skip + ""
+            }
+        };
+        args = [...args, skipArg];
     }
 
     const data = await basicResolve({


### PR DESCRIPTION
Like "first", it is passed through to the original field if no filter /
order of the right side is used.

Otherwise, in the general case, skipping and limiting are done in the
weaver code (and thus the whole data sets need to be transferred from
the origins).

There is one case where it can be optimized: If ordering by the right
side, doing an inner join (filtering on the right side, may be an empty
filter), and there are no multiple left objects that link to the same
right object. In this case, the left side is still queried completely,
but the right side gets the "skip" argument passed through. This case is
can actually be pretty common in the process manager.

Fixes #41.