### PR TITLE
Fix links with typePrefix (#49)

### DIFF
--- a/src/pipeline/pipeline.ts
+++ b/src/pipeline/pipeline.ts
@@ -37,7 +37,7 @@ function createPreMergeModules(context: PreMergeModuleContext, customConfig?: Pi
         new DefaultResolversModule(),
         new ErrorResolversModule(),
         new CustomScalarTypesSerializationModule(),
-        new AbstractTypesModule(),
+        new AbstractTypesModule(context.endpointConfig.typePrefix),
 
         // there should be no reason to change this one either
         new AdditionalMetadataModule(context.endpointConfig),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "removeComments": false,
     "strict": true,
     "alwaysStrict": true,
+    "skipLibCheck": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,


### PR DESCRIPTION
I got the following compile errors:
```
src/extended-schema/extended-schema-transformer.ts:93:19 - error TS2322: Type '((config: GraphQLFieldConfigMapWithMetadata<any, any>, context: FieldsTransformationContext) => GraphQLFieldConfigMapWithMetadata<any, any>) | undefined' is not assignable to type 'TransformationFunction<GraphQLFieldConfigMapWithMetadata<any, any>, FieldsTransformationContext>'.
  Type 'undefined' is not assignable to type 'TransformationFunction<GraphQLFieldConfigMapWithMetadata<any, any>, FieldsTransformationContext>'.

93             const fn: TransformationFunction<GraphQLFieldConfigMapWithMetadata<any, any>, FieldsTransformationContext> = maybeDo(transformer.transformFields, fn => fn.bind(transformer));
                     ~~

src/pipeline/helpers/link-helpers.ts:262:5 - error TS2740: Type '{ [key: string]: any; }' is missing the following properties from type 'any[]': length, pop, push, concat, and 26 more.

262     return fetchBatchOneToOne(keys);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 2 errors.
```
So I added `"skipLibCheck": true`